### PR TITLE
Friendlier ioc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,17 +14,34 @@ repositories {
     jcenter()
 }
 
+configurations.configureEach {
+    it.resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == 'org.codehaus.groovy') {
+                details.useVersion "3.0.2"
+            }
+        }
+    }
+}
+
 dependencies {
     implementation platform('org.apache.logging.log4j:log4j-bom:2.13.0')
-    implementation 'org.codehaus.groovy:groovy:2.5.8'
+    implementation 'org.codehaus.groovy:groovy'
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'io.dropwizard.metrics:metrics-core:4.1.2'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     testImplementation 'org.apache.logging.log4j:log4j-core::tests'
-    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+    testImplementation 'org.spockframework:spock-core:2.0-M2-groovy-3.0'
     testImplementation 'org.objenesis:objenesis:3.1'
     testImplementation 'cglib:cglib-nodep:3.3.0'
+}
+
+quality {
+    // https://github.com/CodeNarc/CodeNarc/issues/426
+    // But codenarc 1.5 seems to be incompatible with Groovy 3
+    // codenarcVersion = '1.5'
+    codenarc = false
 }
 
 wrapper {

--- a/src/main/groovy/com/hpe/amce/translation/impl/ActualStageProcessor.groovy
+++ b/src/main/groovy/com/hpe/amce/translation/impl/ActualStageProcessor.groovy
@@ -1,0 +1,38 @@
+package com.hpe.amce.translation.impl
+
+import javax.annotation.Nonnull
+import javax.annotation.Nullable
+
+/**
+ * Iterates over elements of batch and delegates to {@link AroundElement#translateElement} to actually
+ * process each element.
+ *
+ * C - type of translation context.
+ *
+ * @see ActualStageProcessor#aroundElement
+ */
+class ActualStageProcessor<C> implements AroundStage<C> {
+
+    /**
+     * Applies translation to each element.
+     */
+    @Nonnull
+    final AroundElement<C> aroundElement
+
+    /**
+     * Creates an instance.
+     * @param aroundElement Processing to apply to each element of a batch.
+     */
+    ActualStageProcessor(@Nonnull AroundElement<C> aroundElement) {
+        this.aroundElement = aroundElement
+    }
+
+    @Override
+    @Nonnull
+    List<?> applyStage(@Nonnull String stageName,
+                       @Nonnull Closure<List<?>> stageCode, @Nonnull List<?> elements, @Nullable C context) {
+        elements.collectMany { element ->
+            aroundElement.translateElement(stageName, stageCode, element, context) ?: Collections.emptyList()
+        }
+    }
+}

--- a/src/main/groovy/com/hpe/amce/translation/impl/AroundElement.groovy
+++ b/src/main/groovy/com/hpe/amce/translation/impl/AroundElement.groovy
@@ -16,7 +16,7 @@ interface AroundElement<C> {
      * @param element Element to be translated. Can be null if null was passed.
      * @param context Translation context or null if not specified.
      * @return Result of translating specified element using specified stage.
-     * See {@link DecorableStagedBatchTranslator#processingStages}.
+     * See {@link StagesCaller#processingStages}.
      */
     @Nonnull
     List<?> translateElement(@Nonnull String stageName,

--- a/src/main/groovy/com/hpe/amce/translation/impl/AroundElement.groovy
+++ b/src/main/groovy/com/hpe/amce/translation/impl/AroundElement.groovy
@@ -7,6 +7,8 @@ import javax.annotation.Nullable
  * Defines what to do for each element of a batch.
  *
  * C - type of translation context.
+ *
+ * @see AroundElement#translateElement
  */
 interface AroundElement<C> {
     /**

--- a/src/main/groovy/com/hpe/amce/translation/impl/AroundStage.groovy
+++ b/src/main/groovy/com/hpe/amce/translation/impl/AroundStage.groovy
@@ -5,6 +5,8 @@ import javax.annotation.Nullable
 
 /**
  * Defines what to do for each translation stage.
+ *
+ * @see AroundStage#applyStage
  */
 interface AroundStage<C> {
     /**

--- a/src/main/groovy/com/hpe/amce/translation/impl/BatchDumper.groovy
+++ b/src/main/groovy/com/hpe/amce/translation/impl/BatchDumper.groovy
@@ -8,6 +8,8 @@ import javax.annotation.Nullable
  *
  * E - type of elements.
  * C - translation context.
+ *
+ * @see BatchDumper#dumpBatch
  */
 interface BatchDumper<E,C> {
 

--- a/src/main/groovy/com/hpe/amce/translation/impl/FormattingToStringDumper.groovy
+++ b/src/main/groovy/com/hpe/amce/translation/impl/FormattingToStringDumper.groovy
@@ -23,9 +23,12 @@ import javax.annotation.Nullable
  * {@link StringBuilder} is used internally to concatenate all necessary information.
  * {@link FormattingToStringDumper#estimatedDumpedEventSize} can be adjusted
  * to avoid resizing of this buffer.
+ *
+ * E - type of elements.
+ * C - translation context.
  */
 @CompileStatic
-class FormattingToStringDumper implements BatchDumper<Object, Object>, StageDumper<Object> {
+class FormattingToStringDumper<E, C> implements BatchDumper<E, C>, StageDumper<C> {
 
     /**
      * Dumps a batch of elements.
@@ -87,14 +90,14 @@ class FormattingToStringDumper implements BatchDumper<Object, Object>, StageDump
     int estimatedDumpedEventSize = 10 * 1024
 
     @Override
-    String dumpBatch(@Nullable List<Object> batch, @Nullable Object context) {
+    String dumpBatch(@Nullable List<E> batch, @Nullable C context) {
         StringBuilder buffer = makeBufferForBatch(batch)
         dumpBatchToBuffer(batch, context, buffer)
         buffer.toString()
     }
 
     @Override
-    String dumpBeforeStage(@Nonnull String stageName, @Nullable List<?> batch, @Nullable Object context) {
+    String dumpBeforeStage(@Nonnull String stageName, @Nullable List<?> batch, @Nullable C context) {
         StringBuilder buffer = makeBufferForBatch(batch)
         buffer << stageName << ' <- '
         dumpBatchToBuffer(batch, context, buffer)
@@ -102,7 +105,7 @@ class FormattingToStringDumper implements BatchDumper<Object, Object>, StageDump
     }
 
     @Override
-    String dumpAfterStage(@Nonnull String stageName, @Nullable List<?> batch, @Nullable Object context) {
+    String dumpAfterStage(@Nonnull String stageName, @Nullable List<?> batch, @Nullable C context) {
         StringBuilder buffer = makeBufferForBatch(batch)
         buffer << stageName << ' -> '
         dumpBatchToBuffer(batch, context, buffer)

--- a/src/main/groovy/com/hpe/amce/translation/impl/StageCaller.groovy
+++ b/src/main/groovy/com/hpe/amce/translation/impl/StageCaller.groovy
@@ -7,6 +7,8 @@ import javax.annotation.Nullable
 
 /**
  * Calls actual translator to translate element.
+ *
+ * Actual translator means closure specified for a particular stage.
  */
 @CompileStatic
 class StageCaller<C> implements AroundElement<C> {

--- a/src/main/groovy/com/hpe/amce/translation/impl/StageDumper.groovy
+++ b/src/main/groovy/com/hpe/amce/translation/impl/StageDumper.groovy
@@ -7,6 +7,9 @@ import javax.annotation.Nullable
  * Dumps to string a batch of elements at specified stage.
  *
  * C - type of translation context.
+ *
+ * @see StageDumper#dumpBeforeStage
+ * @see StageDumper#dumpAfterStage
  */
 interface StageDumper<C> {
 

--- a/src/main/groovy/com/hpe/amce/translation/impl/StagesCaller.groovy
+++ b/src/main/groovy/com/hpe/amce/translation/impl/StagesCaller.groovy
@@ -1,0 +1,72 @@
+package com.hpe.amce.translation.impl
+
+import com.hpe.amce.translation.BatchTranslator
+
+import javax.annotation.Nonnull
+import javax.annotation.Nullable
+
+/**
+ * Iterates over list of processing stages and delegates to {@link AroundStage#applyStage} for each of them.
+ *
+ * Each next stage gets input produced by previous stage.
+ *
+ * O - type of source elements.
+ * R - type of result elements.
+ * C - type of translation context.
+ *
+ * @see StagesCaller#processingStages
+ * @see StagesCaller#aroundStage
+ */
+class StagesCaller<O, R, C> implements BatchTranslator<O, R, C> {
+
+    /**
+     * Processing stages.
+     * <br/>
+     * Keys are stage names and entries are closures that do the processing.
+     * <br/>
+     * The closures should take two parameters.
+     * Where first parameter is a single event being processed.
+     * Its type should be a type of raw event for the first stage.
+     * For the second and further stages, its type should be the same
+     * as output of previous stage. For example, if previous stage
+     * is just a filter on raw events then for the current stage,
+     * the first parameter should also be of raw event type.
+     * Second parameter has type C and represents context (extra parameters) passed to
+     * {@link #translateBatch}.
+     * <br/>
+     * The closure should return list of processed events (zero if filtered out,
+     * exactly one for one-to-one translation, more than one if any extra
+     * events are to be injected).
+     * <br/>
+     * Stages are called in whatever order map iterates them so use ordered maps.
+     */
+    @Nonnull
+    final Map<String, Closure<List<?>>> processingStages
+
+    /**
+     * Applies translation stage to a batch of elements.
+     */
+    @Nonnull
+    final AroundStage<C> aroundStage
+
+    /**
+     * Creates an instance.
+     * @param processingStages Definition of processing stages.
+     * @param aroundStage What to do for each stage.
+     * @see StagesCaller#processingStages
+     * @see StagesCaller#aroundStage
+     */
+    StagesCaller(Map<String, Closure<List<?>>> processingStages, AroundStage<C> aroundStage) {
+        this.processingStages = processingStages
+        this.aroundStage = aroundStage
+    }
+
+    @Override
+    List<R> translateBatch(@Nullable List<O> elements, @Nullable C context) {
+        List<?> result = elements
+        processingStages.each { stageName, stageCode ->
+            result = result != null ? aroundStage.applyStage(stageName, stageCode, result, context) : []
+        }
+        result
+    }
+}


### PR DESCRIPTION
Make batch translator configuration API friendlier for IoC by avoiding usage of nested classes that groovy handles especially badly.